### PR TITLE
[orchestration] wrap missing dashboard fields in OrchestratorUpdateError

### DIFF
--- a/src/orchestration/main.py
+++ b/src/orchestration/main.py
@@ -114,7 +114,7 @@ class QualityThresholdOrchestrator:
                     self._last_config = config
                     return config
 
-            except (FileNotFoundError, json.JSONDecodeError, asyncio.TimeoutError) as e:
+            except (FileNotFoundError, json.JSONDecodeError, asyncio.TimeoutError, ValueError) as e:
                 if attempt == retries - 1:
                     raise OrchestratorUpdateError(f"Failed to read dashboard config after {retries} attempts", e)
 

--- a/tests/test_quality_threshold_orchestrator.py
+++ b/tests/test_quality_threshold_orchestrator.py
@@ -129,8 +129,58 @@ class TestQualityThresholdOrchestrator(unittest.TestCase):
 
         orchestrator = QualityThresholdOrchestrator(self.dashboard_path)
 
-        with self.assertRaises(OrchestratorUpdateError):
+        with self.assertRaises(OrchestratorUpdateError) as cm:
             await orchestrator.read_current_config()
+
+        self.assertIsInstance(cm.exception.cause, ValueError)
+
+    async def test_read_current_config_missing_project_phase(self):
+        """read_current_config wraps missing project_phase errors."""
+        config = dict(self.initial_config)
+        del config["project_phase"]
+
+        with open(self.dashboard_path, 'w') as f:
+            json.dump(config, f)
+
+        orchestrator = QualityThresholdOrchestrator(self.dashboard_path)
+
+        with self.assertRaises(OrchestratorUpdateError) as cm:
+            await orchestrator.read_current_config()
+
+        self.assertIsInstance(cm.exception.cause, ValueError)
+        self.assertIn("project_phase", str(cm.exception.cause))
+
+    async def test_read_current_config_missing_gate_thresholds(self):
+        """read_current_config wraps missing gate_thresholds errors."""
+        config = dict(self.initial_config)
+        del config["gate_thresholds"]
+
+        with open(self.dashboard_path, 'w') as f:
+            json.dump(config, f)
+
+        orchestrator = QualityThresholdOrchestrator(self.dashboard_path)
+
+        with self.assertRaises(OrchestratorUpdateError) as cm:
+            await orchestrator.read_current_config()
+
+        self.assertIsInstance(cm.exception.cause, ValueError)
+        self.assertIn("gate_thresholds", str(cm.exception.cause))
+
+    async def test_read_current_config_missing_learning_adjustments(self):
+        """read_current_config wraps missing learning_adjustments errors."""
+        config = dict(self.initial_config)
+        del config["learning_adjustments"]
+
+        with open(self.dashboard_path, 'w') as f:
+            json.dump(config, f)
+
+        orchestrator = QualityThresholdOrchestrator(self.dashboard_path)
+
+        with self.assertRaises(OrchestratorUpdateError) as cm:
+            await orchestrator.read_current_config()
+
+        self.assertIsInstance(cm.exception.cause, ValueError)
+        self.assertIn("learning_adjustments", str(cm.exception.cause))
 
     async def test_phase_transition_success(self):
         """Test successful phase transition."""


### PR DESCRIPTION
## Summary
- Catch `ValueError` in `read_current_config` and re-raise as `OrchestratorUpdateError` for consistent error handling
- Add tests ensuring missing dashboard fields are wrapped and reported via `OrchestratorUpdateError`

## Testing
- `python scripts/validate_config.py sample-app` *(fails: capabilities.yaml, sprint.yaml, workflow-state schema validation)*
- `pytest -q` *(fails: Coverage failure: total of 26 is less than fail-under=85)*
- `ruff check .` *(fails: numerous lint errors)*
- `npm run lint` *(fails: Missing script: lint)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c72dd7948322a22a3b00d6e2d533