### PR TITLE
[memory-bank] add quality threshold evaluation

### DIFF
--- a/tests/learning_quality_control.test.js
+++ b/tests/learning_quality_control.test.js
@@ -32,3 +32,34 @@ test('runQualityGate handles invalid gate type', async () => {
   assert.equal(result.passed, false);
   assert.equal(result.error_type, 'QualityGateError');
 });
+
+test('runQualityGate passes when checks meet threshold', async () => {
+  const qc = createControl();
+  qc.runDocumentationChecks = async () => [
+    { check: 'doc', passed: true, score: 0.9 },
+  ];
+  const result = await qc.runQualityGate('artifact');
+  assert.equal(result.passed, true);
+  assert.equal(result.overall_score, 0.9);
+});
+
+test('runQualityGate fails when average below threshold', async () => {
+  const qc = createControl();
+  qc.runDocumentationChecks = async () => [
+    { check: 'doc', passed: true, score: 0.7 },
+  ];
+  const result = await qc.runQualityGate('artifact');
+  assert.equal(result.passed, false);
+  assert.equal(result.overall_score, 0.7);
+});
+
+test('runQualityGate passes at threshold edge case', async () => {
+  const qc = createControl();
+  qc.runDocumentationChecks = async () => [
+    { check: 'a', passed: true, score: 0.9 },
+    { check: 'b', passed: true, score: 0.7 },
+  ];
+  const result = await qc.runQualityGate('artifact');
+  assert.equal(result.overall_score, 0.8);
+  assert.equal(result.passed, true);
+});


### PR DESCRIPTION
## Summary
- compute overall quality gate score and compare to thresholds from `.roo/rules` JSON or `.roomodes` YAML
- expose `getQualityThreshold` helper and store threshold in quality metrics
- cover pass/fail/edge threshold scenarios in quality gate tests

## Testing
- `npm run -s lint || npx eslint memory-bank/lib/learning-quality-control.js tests/learning_quality_control.test.js` *(fails: ESLint couldn't find a config file)*
- `node --test tests/learning_quality_control.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5d16160548322b6bd2a354b4b5073